### PR TITLE
Move server IP to settings.yaml

### DIFF
--- a/Source Code/Client/Upload.py
+++ b/Source Code/Client/Upload.py
@@ -3,7 +3,6 @@ import settings
 import Graphics
 
 class Vars:
-    baseUrl = settings.Variables.serverIP
     latestOnlineX = 0
     latestOnlineY = 0
     latestOnlineZ = 0
@@ -18,7 +17,7 @@ def move_ship(x, y, z, layer, layerid):
     headers = {"xpos": str(x), "ypos": str(y), "zpos": str(z), "layername": layer, "layerid": layerid,
                "name": settings.Variables.displayName, "id" : Vars.shipID}
 
-    requests.post(Vars.baseUrl + "/modifyplayer", headers=headers)
+    requests.post(settings.Variables.serverIP + "/modifyplayer", headers=headers)
 
 
 def new_ship(x, y, z, layer, layerid):
@@ -30,7 +29,7 @@ def new_ship(x, y, z, layer, layerid):
     headers = {"xpos": str(x), "ypos": str(y), "zpos": str(z), "layername": layer, "layerid": layerid,
                "name": settings.Variables.displayName}
 
-    r = requests.post(Vars.baseUrl + "/newplayer", headers=headers)
+    r = requests.post(settings.Variables.serverIP + "/newplayer", headers=headers)
     Vars.shipID = r.text
     print("Assigned ID: " + Vars.shipID)
 
@@ -39,4 +38,4 @@ def still_online():
         return
     headers = {"id" : Vars.shipID}
 
-    requests.post(Vars.baseUrl + "/stillonline", headers=headers)
+    requests.post(settings.Variables.serverIP + "/stillonline", headers=headers)

--- a/Source Code/Client/Upload.py
+++ b/Source Code/Client/Upload.py
@@ -3,7 +3,7 @@ import settings
 import Graphics
 
 class Vars:
-    baseUrl = "http://173.212.194.49:5000"
+    baseUrl = settings.Variables.serverIP
     latestOnlineX = 0
     latestOnlineY = 0
     latestOnlineZ = 0

--- a/Source Code/Client/main.py
+++ b/Source Code/Client/main.py
@@ -44,6 +44,8 @@ def main():
 
     settings.Variables.doUpload = str(read_config("doUpload"))
 
+    settings.Variables.serverIP = read_config("serverIP")
+
     threading.Thread(target=refresh_coordinates_thread).start()
     threading.Thread(target=still_online_thread).start()
     Graphics.start_gui()

--- a/Source Code/Client/settings.yaml
+++ b/Source Code/Client/settings.yaml
@@ -11,3 +11,5 @@ layerID: 'bcxwoIKlAUCSJAwq'
 #This doesn't do anything. It'll be removed, but I'm currently in change freeze before release.
 layerName: 'Dev layer'
 doUpload: 'True'
+
+serverIP: 'http://173.212.194.49:5000"'

--- a/Source Code/Client/settings.yaml
+++ b/Source Code/Client/settings.yaml
@@ -12,4 +12,4 @@ layerID: 'bcxwoIKlAUCSJAwq'
 layerName: 'Dev layer'
 doUpload: 'True'
 
-serverIP: 'http://173.212.194.49:5000"'
+serverIP: 'http://173.212.194.49:5000'


### PR DESCRIPTION
This would allow people to run a custom StarBeam server and change the IP more easily for their clients, without the need to customize a Python script. Untested, but it seems like a simple/straightforward enough change.